### PR TITLE
Add `cipher_compatibility` support for SQLCipher

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -1019,6 +1019,7 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 
 	// PRAGMA's
 	encryptKey := ""
+	cipher_compatibility := -1
 	autoVacuum := -1
 	busyTimeout := 5000
 	caseSensitiveLike := -1
@@ -1043,6 +1044,15 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 		// _key
 		if val := params.Get("_key"); val != "" {
 			encryptKey = val
+		}
+
+		// _cipher_compatibility
+		if val := params.Get("_cipher_compatibility"); val != "" {
+			iv, err := strconv.ParseInt(val, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid _cipher_compatibility: %v: %v", val, err)
+			}
+			cipher_compatibility = int(iv)
 		}
 
 		// Authentication
@@ -1404,6 +1414,15 @@ func (d *SQLiteDriver) Open(dsn string) (driver.Conn, error) {
 	// The key pragma should be always called first
 	if encryptKey != "" {
 		if err := exec(fmt.Sprintf(`PRAGMA key = "%s";`, encryptKey)); err != nil {
+			C.sqlite3_close_v2(db)
+			return nil, err
+		}
+	}
+
+	// Cipher Compatibility
+	// The cipher_compatibility pragma should be called immediately after if provided
+	if cipher_compatibility > -1 {
+		if err := exec(fmt.Sprintf("PRAGMA cipher_compatibility = %d;", cipher_compatibility)); err != nil {
 			C.sqlite3_close_v2(db)
 			return nil, err
 		}


### PR DESCRIPTION
This commit introduces support for the `cipher_compatibility` PRAGMA in the SQLCipher Go wrapper. 

The change allows setting the compatibility level for SQLCipher, enabling backward compatibility with databases created with older versions of SQLCipher. This feature is crucial for applications that need to interact with databases across different versions of SQLCipher. 

Modifications include parsing the compatibility level from parameters, handling errors, and invoking the PRAGMA command post-connection setup. Error messages have been added for invalid compatibility levels to ensure that users are informed of incorrect usage. Additionally, the default value is set to `-1` to maintain existing behavior when the parameter is not explicitly provided.