### PR TITLE
fix: build for alpine3.19

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -21,7 +21,6 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_HAS_CODEC
 #cgo LDFLAGS: -lcrypto
 #cgo CFLAGS: -DSQLITE_ENABLE_RTREE -DSQLITE_THREADSAFE=1 -DHAVE_USLEEP=1
-#cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
 #cgo CFLAGS: -DSQLITE_ENABLE_FTS3 -DSQLITE_ENABLE_FTS3_PARENTHESIS -DSQLITE_ENABLE_FTS4_UNICODE61
 #cgo CFLAGS: -DSQLITE_TRACE_SIZE_LIMIT=15
 #cgo CFLAGS: -DSQLITE_OMIT_DEPRECATED
@@ -29,7 +28,6 @@ package sqlite3
 #cgo CFLAGS: -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1
 #cgo CFLAGS: -DSQLITE_ENABLE_UPDATE_DELETE_LIMIT
 #cgo CFLAGS: -Wno-deprecated-declarations
-#cgo linux,!android CFLAGS: -DHAVE_PREAD64=1 -DHAVE_PWRITE64=1
 #ifndef USE_LIBSQLITE3
 #include <sqlite3-binding.h>
 #else
@@ -52,6 +50,18 @@ package sqlite3
 
 #ifndef SQLITE_DETERMINISTIC
 # define SQLITE_DETERMINISTIC 0
+#endif
+
+#if defined(HAVE_PREAD64) && defined(HAVE_PWRITE64)
+# undef USE_PREAD
+# undef USE_PWRITE
+# define USE_PREAD64 1
+# define USE_PWRITE64 1
+#elif defined(HAVE_PREAD) && defined(HAVE_PWRITE)
+# undef USE_PREAD
+# undef USE_PWRITE
+# define USE_PREAD64 1
+# define USE_PWRITE64 1
 #endif
 
 static int


### PR DESCRIPTION
Applying fix from https://github.com/mattn/go-sqlite3/commit/00b02e0ba98effd5f157d39216e244af8a807f9b to resolve build errors when building for Alpine 3.19

## Before change

```
=> ERROR [builder 2/4] RUN CGO_ENABLED=1 GOOS="linux" GOARCH="amd64" go build -o /go/bin/prog ./cmd/prog               9.1s
------                                                                                                                                     
> [builder 2/4] RUN CGO_ENABLED=1 GOOS="linux" GOARCH="amd64" go build -o /go/bin/prog ./cmd/prog:                          
8.354 # github.com/ValentinMontmirail/go-sqlcipher                                                                                         
8.354 sqlite3-binding.c:38256:42: error: 'pread64' undeclared here (not in a function); did you mean 'pread'?                              
8.354 38256 |   { "pread64",      (sqlite3_syscall_ptr)pread64,    0  },
8.354       |                                          ^~~~~~~
8.354       |                                          pread
8.354 sqlite3-binding.c:38274:42: error: 'pwrite64' undeclared here (not in a function); did you mean 'pwrite'?
8.354 38274 |   { "pwrite64",     (sqlite3_syscall_ptr)pwrite64,   0  },
8.354       |                                          ^~~~~~~~
8.354       |                                          pwrite
8.354 sqlite3-binding.c: In function 'seekAndRead':
8.354 sqlite3-binding.c:38260:49: error: unknown type name 'off64_t'; did you mean 'off_t'?
8.354 38260 | #define osPread64 ((ssize_t(*)(int,void*,size_t,off64_t))aSyscall[10].pCurrent)
8.354       |                                                 ^~~~~~~
8.354 sqlite3-binding.c:41117:11: note: in expansion of macro 'osPread64'
8.354 41117 |     got = osPread64(id->h, pBuf, cnt, offset);
8.354       |           ^~~~~~~~~
8.354 sqlite3-binding.c:38260:58: error: expected ')' before 'aSyscall'
8.354 38260 | #define osPread64 ((ssize_t(*)(int,void*,size_t,off64_t))aSyscall[10].pCurrent)
8.354       |                   ~                                      ^~~~~~~~
8.354 sqlite3-binding.c:41117:11: note: in expansion of macro 'osPread64'
8.354 41117 |     got = osPread64(id->h, pBuf, cnt, offset);
8.354       |           ^~~~~~~~~
8.354 sqlite3-binding.c: In function 'seekAndWriteFd':
8.354 sqlite3-binding.c:38278:57: error: unknown type name 'off64_t'; did you mean 'off_t'?
8.354 38278 | #define osPwrite64  ((ssize_t(*)(int,const void*,size_t,off64_t))\
8.354       |                                                         ^~~~~~~
8.354 sqlite3-binding.c:41229:17: note: in expansion of macro 'osPwrite64'
8.354 41229 |   do{ rc = (int)osPwrite64(fd, pBuf, nBuf, iOff);}while( rc<0 && errno==EINTR);
8.354       |                 ^~~~~~~~~~
8.354 sqlite3-binding.c:38279:21: error: expected ')' before 'aSyscall'
8.354 38279 |                     aSyscall[13].pCurrent)
8.354       |                     ^~~~~~~~
8.354 sqlite3-binding.c:41229:17: note: in expansion of macro 'osPwrite64'
8.354 41229 |   do{ rc = (int)osPwrite64(fd, pBuf, nBuf, iOff);}while( rc<0 && errno==EINTR);
8.354       |                 ^~~~~~~~~~
8.354 sqlite3-binding.c:38278:21: note: to match this '('
8.354 38278 | #define osPwrite64  ((ssize_t(*)(int,const void*,size_t,off64_t))\
8.354       |                     ^
8.354 sqlite3-binding.c:41229:17: note: in expansion of macro 'osPwrite64'
8.354 41229 |   do{ rc = (int)osPwrite64(fd, pBuf, nBuf, iOff);}while( rc<0 && errno==EINTR);
8.354       |                 ^~~~~~~~~~
------
```

## After change

```
 => [builder 2/4] RUN CGO_ENABLED=1 GOOS="linux" GOARCH="amd64" go build -o /go/bin/prog ./cmd/prog                    47.7s
```